### PR TITLE
Fix for endless drag loop on _onSingleTap

### DIFF
--- a/src/automotive.js
+++ b/src/automotive.js
@@ -215,7 +215,7 @@ const openBridge = () => {
     bridgeOpen = true;
 
     // schedule timeout
-    bridgeTimeoutId = setTimeout(
+    bridgeTimeoutId = Registry.setTimeout(
         closeBridge, config.get('bridgeCloseTimeout')
     );
 };


### PR DESCRIPTION
Added Registry.* back to openBridge()

When using _onSingleTap() drag would fire endlessly, until touched again.
Reinstating Registry.* to the openBridge() function, resolves this issue.

Used following settings:
export const automotiveSettings = {
	bridgeCloseTimeout: 110,
	tapDelay: 120,
	doubleTapActive: false,
	beforeDoubleTapDelay: 300,
	flagAsHoldDelay: 250,
	doubleTapMaxDistance: 40,
	externalTouchScreen: false,
	componentBlockBroadcast: true,
	swipeXTreshold: 5,
	swipeYTreshold: 5,
	viewportOffsetX: 0,
	viewportOffsetY: 0,
	touchQueueMaxLength: 250,
	maxForce: 5,
	w: window.innerWidth,
	h: window.innerHeight,
	ipad: true
};