### PR TITLE
Let sticky event calls bubble up

### DIFF
--- a/src/automotive.js
+++ b/src/automotive.js
@@ -322,7 +322,6 @@ export const sticky = (event, recording) => {
         return;
     }
 
-    let handled = false;
     // on first fire after a new recording has started
     // we collect the elements;
     if (!stickyElements.length) {
@@ -331,15 +330,14 @@ export const sticky = (event, recording) => {
         });
     }
     if (stickyElements.length) {
-        stickyElements.forEach((element) => {
-            const local = getLocalPosition(element, recording);
-            if (isFunction(element[event]) && !handled) {
-                element[event](recording, local);
-                handled = true;
+        for (let i = 0; i < stickyElements.length; i++) {
+            const element = stickyElements[i];
+            if (isFunction(element[event])) {
+                const local = getLocalPosition(element, recording);
+                if (element[event](recording, local) !== false) break;
             }
-        });
+        }
     }
-    return handled;
 };
 
 export const handlers = {

--- a/src/automotive.js
+++ b/src/automotive.js
@@ -312,7 +312,6 @@ export const dispatch = (event, recording) => {
 
 /**
  * Keep dispatching event on that we started the hold / drag on
- * @todo: do we want to accept false explicit for event bubble?
  *
  * @param event
  * @param recording


### PR DESCRIPTION
As discussed on the discord: https://discord.com/channels/1020300788016353311/1291329933590659122/1298208537352077362

This pull request would allow developers to have two-way navigation at two different levels of the application by allowing the drag event to bubble up to page level.

Removed the `handled` return value as this was not being used and makes little sense when we are doing event-bubbling. Existence of a eventHandler does not necessarily mean that it handled it (false can mean "can't handle it") nor does a false return value mean that it wasn't handled (false can mean "let others also handle it"). 